### PR TITLE
Add option to provide web links as well as embedded Help links

### DIFF
--- a/src/_includes/steps.ejs
+++ b/src/_includes/steps.ejs
@@ -60,7 +60,11 @@
 							<ul>
 							<% for (var i in tutorialSteps.concept.helpLinks.details) { %>
 								<% var link = tutorialSteps.concept.helpLinks.details[i] %>
+								<% if ((link.type) && (link.type == "web")) { %>
+								<li> <a href="<%= link.link %>" title="<%= link.title %> <%= link.description %>"><%= link.description %></a> </li>
+								<% } else { %>								
 								<li> <a href="javascript:;" onclick="openHelpSystem('/<%= link.link %>')" title="<%= link.title %><%= link.description %>"><%= link.description %></a> </li>
+							   <% } %>	
 							<% } %>
 							</ul>
 						</div>	
@@ -82,7 +86,11 @@
 							<ul>
 							<% for (var i in tutorialSteps.create.helpLinks.details) { %>
 								<% var link = tutorialSteps.create.helpLinks.details[i] %>
+								<% if ((link.type) && (link.type == "web")) { %>
+								<li> <a href="<%= link.link %>" title="<%= link.title %> <%= link.description %>"><%= link.description %></a> </li>
+								<% } else { %>								
 								<li> <a href="javascript:;" onclick="openHelpSystem('/<%= link.link %>')" title="<%= link.title %><%= link.description %>"><%= link.description %></a> </li>
+							   <% } %>	
 							<% } %>
 							</ul>
 						</div>
@@ -107,7 +115,11 @@
 							<ul>
 							<% for (var i in tutorialSteps.prepare.helpLinks.details) { %>
 								<% var link = tutorialSteps.prepare.helpLinks.details[i] %>
+								<% if ((link.type) && (link.type == "web")) { %>
+								<li> <a href="<%= link.link %>" title="<%= link.title %> <%= link.description %>"><%= link.description %></a> </li>
+								<% } else { %>								
 								<li> <a href="javascript:;" onclick="openHelpSystem('/<%= link.link %>')" title="<%= link.title %><%= link.description %>"><%= link.description %></a> </li>
+							   <% } %>	
 							<% } %>
 							</ul>
 						</div>
@@ -165,7 +177,11 @@
 							<ul>
 							<% for (var i in tutorialSteps.run.helpLinks.details) { %>
 								<% var link = tutorialSteps.run.helpLinks.details[i] %>
+								<% if ((link.type) && (link.type == "web")) { %>
+								<li> <a href="<%= link.link %>" title="<%= link.title %> <%= link.description %>"><%= link.description %></a> </li>
+								<% } else { %>								
 								<li> <a href="javascript:;" onclick="openHelpSystem('/<%= link.link %>')" title="<%= link.title %><%= link.description %>"><%= link.description %></a> </li>
+							   <% } %>	
 							<% } %>
 							</ul>
 						</div>

--- a/src/tutorialExample/en/_data.json
+++ b/src/tutorialExample/en/_data.json
@@ -72,12 +72,19 @@
           ]
         },
         "helpLinks":{
+		  "_helpLinksComment": "Helplinks that have a type:web attribute are rendered as web links. Otherwise, links are assumed to be to embedded Help topics in the Knowledge Center.",
           "title":"Find out more",
           "details":[
             {
               "title":"Knowledge Center link to ",
               "description":"Developing integration solutions by using applications",
               "link":"com.ibm.etools.mft.doc/bi12002_.htm"
+            },
+			{
+              "title":"GitHub link to ",
+              "description":"DFDL Schemas",
+              "link":"http://github.com/DFDLSchemas",
+			  "type":"web"
             }
           ]
         }


### PR DESCRIPTION
Add optional attribute "type":"web" to link objects to have them output as web links rather than a Javascript call to open the embedded Help system
