### PR TITLE
Update change(s) to:

### DIFF
--- a/src/_data.json
+++ b/src/_data.json
@@ -18,7 +18,7 @@
 "separatorFrameworkListJSON":{},
 	"_comments":
 	{
-"separator-ot4i":"",
+"separator-ot4i":{},
 		"repoUrlProtocol":"http://",
 		"repoUrlSite":"ot4i.github.io",
 		
@@ -34,8 +34,9 @@
 		"repoUrlFilepathJs2java":"/ot4i.tutorials/dist/js/js2java.js",
 		"repoUrlFilepathJs2javaSteps":"/ot4i.tutorials/dist/js/js2java_steps.js",
 		"repoUrlFilepathActionIcon":"/ot4i.tutorials/dist/images/icons/ibmdesign/back-right-previous_128-orange.png",
+		"repoUrlFilepathExitIcon":"/ot4i.tutorials/dist/images/icons/ibmdesign/close-cancel-error_128-red.png",
 
-"separator-Local":"",
+"separator-Local":{},
 		"repoUrlProtocol":"http://",
 		"repoUrlSite":"localhost:3000",
 		
@@ -51,33 +52,35 @@
 		"repoUrlFilepathJs2java":"/js/js2java.js",
 		"repoUrlFilepathJs2javaSteps":"/js/js2java_steps.js",
 		
-		"repoUrlFilepathActionIcon":"/images/icons/ibmdesign/back-right-previous_128-orange.png"
+		"repoUrlFilepathActionIcon":"/images/icons/ibmdesign/back-right-previous_128-orange.png",
+		"repoUrlFilepathExitIcon":"/images/icons/ibmdesign/close-cancel-error_128-red.png"
 	},
 	"header":
-	  {
-	    "lang":"en-us",
-	    "charset":"UTF-8",
-	    "metaDescription":"IBM Integration Bus V10 Tutorial",
-	    "metaAuthor":"IBM",
-	    "keywords":"keywords",
-	    "robots":"index,follow",
-	    "source":"IBM Integration Bus V10 Tutorial",
-		
-		"repoUrlProtocol":"http://",
-		"repoUrlSite":"localhost:3000",
-		
-		"repoUrlFilepathCss":"/css/main.css",
-		"repoUrlFilepathCssApp":"/css/app.css",
-		"repoUrlFilepathJs":"/js/main.js",
-		
-		"repoUrlFilepathFoundationModernizr":"/js/vendor/modernizr.js",
-		"repoUrlFilepathFoundationJquery":"/js/vendor/jquery.js",
-		"repoUrlFilepathFoundationJs":"/js/vendor/foundation.min.js",
-		
-		"repoUrlFilepathJson2":"/js/json2.js",
-		"repoUrlFilepathJs2java":"/js/js2java.js",
-		"repoUrlFilepathJs2javaSteps":"/js/js2java_steps.js",
-		
-		"repoUrlFilepathActionIcon":"/images/icons/ibmdesign/back-right-previous_128-orange.png"
-	  }
+	{
+	"lang":"en-us",
+	"charset":"UTF-8",
+	"metaDescription":"IBM Integration Bus V10 Tutorial",
+	"metaAuthor":"IBM",
+	"keywords":"keywords",
+	"robots":"index,follow",
+	"source":"IBM Integration Bus V10 Tutorial",
+
+	"repoUrlProtocol":"http://",
+	"repoUrlSite":"localhost:3000",
+
+	"repoUrlFilepathCss":"/css/main.css",
+	"repoUrlFilepathCssApp":"/css/app.css",
+	"repoUrlFilepathJs":"/js/main.js",
+
+	"repoUrlFilepathFoundationModernizr":"/js/vendor/modernizr.js",
+	"repoUrlFilepathFoundationJquery":"/js/vendor/jquery.js",
+	"repoUrlFilepathFoundationJs":"/js/vendor/foundation.min.js",
+
+	"repoUrlFilepathJson2":"/js/json2.js",
+	"repoUrlFilepathJs2java":"/js/js2java.js",
+	"repoUrlFilepathJs2javaSteps":"/js/js2java_steps.js",
+
+	"repoUrlFilepathActionIcon":"/images/icons/ibmdesign/back-right-previous_128-orange.png",
+	"repoUrlFilepathExitIcon":"/images/icons/ibmdesign/close-cancel-error_128-red.png"
+	}
 } 

--- a/src/_data.json
+++ b/src/_data.json
@@ -53,34 +53,34 @@
 		"repoUrlFilepathJs2javaSteps":"/js/js2java_steps.js",
 		
 		"repoUrlFilepathActionIcon":"/images/icons/ibmdesign/back-right-previous_128-orange.png",
-		"repoUrlFilepathExitIcon":"/images/icons/ibmdesign/close-cancel-error_128-red.png"
+		"repoUrlFilepathExitIcon":"/images/icons/ibmdesign/close-cancel-error_128-red.png"		
+
 	},
 	"header":
 	{
-	"lang":"en-us",
-	"charset":"UTF-8",
-	"metaDescription":"IBM Integration Bus V10 Tutorial",
-	"metaAuthor":"IBM",
-	"keywords":"keywords",
-	"robots":"index,follow",
-	"source":"IBM Integration Bus V10 Tutorial",
+		"lang":"en-us",
+		"charset":"UTF-8",
+		"metaDescription":"IBM Integration Bus V10 Tutorial",
+		"metaAuthor":"IBM",
+		"keywords":"keywords",
+		"robots":"index,follow",
+		"source":"IBM Integration Bus V10 Tutorial",
 
-	"repoUrlProtocol":"http://",
-	"repoUrlSite":"localhost:3000",
-
-	"repoUrlFilepathCss":"/css/main.css",
-	"repoUrlFilepathCssApp":"/css/app.css",
-	"repoUrlFilepathJs":"/js/main.js",
-
-	"repoUrlFilepathFoundationModernizr":"/js/vendor/modernizr.js",
-	"repoUrlFilepathFoundationJquery":"/js/vendor/jquery.js",
-	"repoUrlFilepathFoundationJs":"/js/vendor/foundation.min.js",
-
-	"repoUrlFilepathJson2":"/js/json2.js",
-	"repoUrlFilepathJs2java":"/js/js2java.js",
-	"repoUrlFilepathJs2javaSteps":"/js/js2java_steps.js",
-
-	"repoUrlFilepathActionIcon":"/images/icons/ibmdesign/back-right-previous_128-orange.png",
-	"repoUrlFilepathExitIcon":"/images/icons/ibmdesign/close-cancel-error_128-red.png"
+		"repoUrlProtocol":"http://",
+		"repoUrlSite":"ot4i.github.io",
+		
+		"repoUrlFilepathCss":"/ot4i.tutorials/dist/css/main.css",
+		"repoUrlFilepathCssApp":"/ot4i.tutorials/dist/css/app.css",
+		"repoUrlFilepathJs":"/ot4i.tutorials/dist/js/main.js",
+		
+		"repoUrlFilepathFoundationModernizr":"/ot4i.tutorials/dist/js/vendor/modernizr.js",
+		"repoUrlFilepathFoundationJquery":"ot4i.tutorials/dist/js/vendor/jquery.js",
+		"repoUrlFilepathFoundationJs":"/ot4i.tutorials/dist/js/vendor/foundation.min.js",
+		
+		"repoUrlFilepathJson2":"/ot4i.tutorials/dist/js/json2.js",
+		"repoUrlFilepathJs2java":"/ot4i.tutorials/dist/js/js2java.js",
+		"repoUrlFilepathJs2javaSteps":"/ot4i.tutorials/dist/js/js2java_steps.js",
+		"repoUrlFilepathActionIcon":"/ot4i.tutorials/dist/images/icons/ibmdesign/back-right-previous_128-orange.png",
+		"repoUrlFilepathExitIcon":"/ot4i.tutorials/dist/images/icons/ibmdesign/close-cancel-error_128-red.png"
 	}
 } 

--- a/src/_includes/steps.ejs
+++ b/src/_includes/steps.ejs
@@ -75,7 +75,11 @@
 					</div>
 				</div>
 		    	<div class="content" id="panel21">
+		    		<% if (tutorialSteps.create.actions) { %>
 		    		<div class="small-10 medium-10 large-10 columns divider">
+					<% } else { %>
+					<div class="small-12 medium-12 large-12 columns">
+					<% } %>
 				      	<div class="row content-details">
 					      	<h4><%= tutorialSteps.create.overview.heading %></h4>
 					        <% var sections = tutorialSteps.create.overview.sections %>
@@ -103,13 +107,17 @@
 					<div class="small-2 medium-2 large-2 columns">
 					<% for (var i in tutorialSteps.create.actions.details) { %>
 					<% var link = tutorialSteps.create.actions.details[i] %>
-					<h4 class="tkaction"><a href="javascript:;" onclick="<%= link.method %>; openResource('<%= tutorialCommon.resourceToOpen %>');"> <%= link.name %> <img class="icon-image" src="<%= header.repoUrlProtocol %><%= header.repoUrlSite %><%= header.repoUrlFilepathActionIcon %>" /></a></h4>						
+					<h4 class="tkaction"><a href="javascript:;" onclick="<%= link.method %>; openResource('<%= tutorialCommon.resourceToOpen %>');"> <%= link.name %> <img class="icon-image" src="<%= header.repoUrlProtocol %><%= header.repoUrlSite %><%= header.repoUrlFilepathActionIcon %>" /></a></h4>
+					<% } %>					
 				    </div>
-					<% } %>
 					<% } %>
 		    	</div>
 		    	<div class="content" id="panel31">
+					<% if (tutorialSteps.prepare.actions) { %>
 		    		<div class="small-10 medium-10 large-10 columns divider">
+					<% } else { %>
+					<div class="small-12 medium-12 large-12 columns">
+					<% } %>
 						<div class="row content-details">
 						  	<h4><%= tutorialSteps.prepare.overview.heading %></h4>
 						    <% var sections = tutorialSteps.prepare.overview.sections %>
@@ -133,12 +141,21 @@
 						</div>
 						<% } %>	
 					</div>
+					<% if (tutorialSteps.prepare.actions) { %>
 					<div class="small-2 medium-2 large-2 columns">
-						<h4 class="tkaction"><a href="javascript:;" onclick="deployArtifacts();"> <%= tutorialSteps.prepare.actionName %> <img class="icon-image" src="http://ot4i.github.io/ot4i.tutorials/dist/images/icons/ibmdesign/back-right-previous_128-orange.png" /></a></h4>
+					<% for (var i in tutorialSteps.prepare.actions.details) { %>
+					<% var link = tutorialSteps.prepare.actions.details[i] %>
+					<h4 class="tkaction"><a href="javascript:;" onclick="<%= link.method %>;"> <%= link.name %> <img class="icon-image" src="<%= header.repoUrlProtocol %><%= header.repoUrlSite %><%= header.repoUrlFilepathActionIcon %>" /></a></h4>						
+				    <% } %>					
 				    </div>
+					<% } %>
 		    	</div>
 		    	<div class="content" id="panel41">
+		    		<% if (tutorialSteps.run.actions) { %>
 		    		<div class="small-10 medium-10 large-10 columns divider">
+					<% } else { %>
+					<div class="small-12 medium-12 large-12 columns">
+					<% } %>
 				    	<div class="row content-details">
 					      	<h4><%= tutorialSteps.run.overview.heading %></h4>
 					        <% var sections = tutorialSteps.run.overview.sections %>
@@ -195,9 +212,21 @@
 						</div>
 						<% } %>	
 					</div>
+					<% if ((tutorialSteps.run.actions) || (tutorialSteps.run.exits) ) { %>
 					<div class="small-2 medium-2 large-2 columns">
-						<h4 class="tkaction"><a href="javascript:;" onclick="cleanUp();" title="<%= tutorialSteps.run.cleanupDescription %>"><%= tutorialSteps.run.cleanupName %><img class="icon-image" src="http://ot4i.github.io/ot4i.tutorials/dist/images/icons/ibmdesign/back-right-previous_128-orange.png" /></a></h4>
+					<% for (var i in tutorialSteps.run.actions.details) { %>
+					<% var link = tutorialSteps.run.actions.details[i] %>
+					<h4 class="tkaction"><a href="javascript:;" onclick="<%= link.method %>;"> <%= link.name %> <img class="icon-image" src="<%= header.repoUrlProtocol %><%= header.repoUrlSite %><%= header.repoUrlFilepathActionIcon %>" /></a></h4>
+				    <% } %>
+					<% if (tutorialSteps.run.exits) { %>
+					<hr />
+					<% for (var i in tutorialSteps.run.exits.details) { %>
+					<% var link = tutorialSteps.run.exits.details[i] %>
+					<h4 class="tkaction"><a href="javascript:;" onclick="<%= link.method %>;" title="<%= link.description %>"> <%= link.name %> <img class="icon-image" src="<%= header.repoUrlProtocol %><%= header.repoUrlSite %><%= header.repoUrlFilepathExitIcon %>" /></a></h4>
+				    <% } %>
+					<% } %>
 				    </div>
+					<% } %>
 				</div>	
 			</div> <!-- tab-content -->
 		</div> <!-- columns -->

--- a/src/tutorialExample/en/_data.json
+++ b/src/tutorialExample/en/_data.json
@@ -1,244 +1,290 @@
 {
-  "version":"0.5",
-  "pageContent":
-  {
-    "_comments":"JSON object that contains data for page labels, buttons, etc.",
-    "navItems":
+    "version": "0.5",
+    "pageContent": 
 	{
-      "_common":
-	  {
-        "buttonBackToGallery":
+        "_comments": "JSON object that contains data for page labels, buttons, etc.",
+        "navItems": 
 		{
-          "text":"Back To Gallery"
-        },
-        "buttonStartTutorial":
-		{
-          "text":"Start Tutorial"
-        }
-      }
-    }
-  },
-  "tutorial":
-  {
-    "_common":
-	{
-		"name":"HTTP Input to drive a message flow",
-		"shortDescription":"Learn how to use an HTTPInput node to parse JSON data in an IBM Integration Bus message flow by exploring this simple example.",
-		"durationText":"This tutorial takes approximately",
-		"durationTime":"5 minutes",
-		"_resourceToOpenComment":"The ID of the first resource to open when the user imports the tutorial. Resource IDs are defined in the repo_metadata.json Tutorials listing on ot4i.",
-		"resourceToOpen":"MainFlow",
-		"helpLink":
-		{
-		  "text":"IBM Knowledge Center",
-		  "link":"/com.ibm.etools.msgbroker.helphome.doc/help_home_msgbroker.htm"
-		}
-    },
-    "pageDetails":
-	{
-      "topicsName":"Tutorial Topics",
-      "_topicListComment":"A short list of product concepts or tasks demonstrated by this tutorial",
-      "topicList":
-	  [
-        {
-          "title":"HTTP Input node"
-        },
-        {
-          "title":"JSON parsing and writing"
-        },
-        {
-          "title":"Transformation using graphical data mapping"
-        }
-      ],
-      "outcomesName":"Learning outcomes",
-      "_outcomesComment":"A description of what the user will have learned or accomplished by running this tutorial.",
-      "outcomeList":
-	  [
-        {
-          "title":"Use IBM Integration Bus to create and invoke a JSON/HTTP request-response message flow."
-        }
-      ],
-      "summary":{
-        "overviewName":"OVERVIEW",
-        "_overviewComment":"A short description of what happens in this tutorial, and an optional short explanation of the IIB concepts used in this tutorial if necessary for context. What background knowledge must the user have for this to make sense?",
-        "sections":[
-          {
-            "section":"This tutorial demonstrates a simple message flow that receives JSON data over HTTP. The flow transforms the input JSON structure into a different output JSON structure using a graphical data mapping node, and sends this back to the HTTP request."
-          },
-          {
-            "section":"In IBM Integration Bus, an application is a container for all the resources that are required to create a solution. An application can contain IBM Integration Bus resources, such as flows, message definitions, libraries, and JAR files. An application is used to hold the message flow in this tutorial.  If you have a WSDL document that describes a SOAP/HTTP interface you might consider using an integration service instead. See the Integration services (SOAP/HTTP inputs) tutorial for more details."
-          }
-        ]
-      }
-    },
-    "pageSteps":
-	{
-      "concept":
-	  {
-        "overview":
-		{
-          "name":"Overview",
-          "heading":"Overview",
-          "_overviewComment":"A short description of what this tutorial does, and what the user will do to run the tutorial.",
-          "sections":
-		  [
-            {
-              "section":"This tutorial demonstrates a simple message flow that receives JSON data over HTTP. The flow transforms the input JSON structure into a different output JSON structure using a graphical data mapping node and sends this back to the HTTP request."
-            },
-            {
-              "section":"You will import the message flow to your Integration Toolkit workspace, deploy it to your default integration server, and invoke the message flow by using the Flow exerciser."
-            }
-          ]
-        },
-        "helpLinks":{
-		  "_helpLinksComment": "Helplinks that have a type:web attribute are rendered as web links. Otherwise, links are assumed to be to embedded Help topics in the Knowledge Center.",
-          "title":"Find out more",
-          "details":[
-            {
-              "title":"Knowledge Center link to ",
-              "description":"Developing integration solutions by using applications",
-              "link":"com.ibm.etools.mft.doc/bi12002_.htm",
-			  "type":"help"
-            },
+            "_common": 
 			{
-              "title":"GitHub link to ",
-              "description":"DFDL Schemas",
-              "link":"http://github.com/DFDLSchemas",
-			  "type":"web"
-            }
-          ]
-        }
-      },
-      "create":
-	  {
-        "overview":
-		{
-          "name":"Create",
-          "heading":"Import projects",
-          "_createComment":"A description of what will happen when the user clicks Import.",
-          "sections":
-		  [
-            {
-              "section":"The HTTPInputApplication application includes one project that is imported into your workspace."
-            }
-          ]
-        },
-        "helpLinks":
-		{
-          "title":"Find out more",
-          "details":
-		  [
-            {
-              "title":"Knowledge Center link to ",
-              "description":"Developing integration solutions by using applications",
-              "link":"com.ibm.etools.mft.doc/bi12002_.htm"
-            }
-          ]
-        },
-		"actionName":"Import",
-		"actions":
-		{
-			"title":"Create Actions",
-			"details":
-			[
+                "buttonBackToGallery": 
 				{
-					"name":"Import",
-					"method":"importArtifacts()"
-				}
-			]
-		}
-      },
-      "prepare":{
-        "overview":{
-          "name":"Prepare",
-          "heading":"Imported projects",
-          "_prepareComment":"A description of what just happened when the user clicked Import, and what will happen when the user clicks Deploy.",
-          "sections":[
-            {
-              "section":"The HTTPInputApplication application is shown in the Application Development view of your workspace."
-            },
-            {
-              "section":""
-            },
-            {
-              "section":"The application will be deployed to your default integration server. The message flow is then running on your integration server and ready to process messages."
+                    "text": "Back To Gallery"
+                },
+                "buttonStartTutorial": 
+				{
+                    "text": "Start Tutorial"
+                }
             }
-          ]
-        },
-        "helpLinks":
+        }
+    },
+    "tutorial": 
+	{
+        "_common": 
 		{
-          "title":"Find out more",
-          "details":
-		  [
-            {
-              "title":"Knowledge Center link to ",
-              "description":"Developing integration solutions by using integration services",
-              "link":"com.ibm.etools.mft.doc/bi12002_.htm"
+            "name": "HTTP Input to drive a message flow",
+            "shortDescription": "Learn how to use an HTTPInput node to parse JSON data in an IBM Integration Bus message flow by exploring this simple example.",
+            "durationText": "This tutorial takes approximately",
+            "durationTime": "5 minutes",
+            "_resourceToOpenComment": "The ID of the first resource to open when the user imports the tutorial. Resource IDs are defined in the repo_metadata.json Tutorials listing on ot4i.",
+            "resourceToOpen": "MainFlow",
+            "helpLink": 
+			{
+                "text": "IBM Knowledge Center",
+                "link": "/com.ibm.etools.msgbroker.helphome.doc/help_home_msgbroker.htm"
             }
-          ]
         },
-        "actionName":"Deploy"
-      },
-      "run":{
-        "cleanupName":"Clean up",
-        "cleanupDescription":"Clean up and remove any changes made by the tutorial.",
-        "overview":{
-          "name":"Run",
-          "heading":"Follow these steps to complete the tutorial",
-          "_runComment":"The full steps for the user to run through the tutorial. Use 'sections' to render paragraphs, 'steps' with a type of 'ordered' or 'unordered' to render HTML lists, and 'substeps' to render nested lists.",
-          "sections":[
-            {
-              "section":"The HTTPInputApplication application is shown in the Application Development view of your workspace.",
-              "steps":{
-                "type":"ordered",
-                "details":[
-                  {
-                    "details":"Open the HTTPInputMessageFlow, and click the Flow Exerciser icon <img src='http://ot4i.github.io/ot4i.tutorials/dist/images/icons/iib/startFlowExerciser.png' alt='' /> to start recording the message path through the flow."
-                  },
-                  {
-                    "details":"Click the Send Message icon <img src='http://ot4i.github.io/ot4i.tutorials/dist/images/icons/iib/sendMessage.png' alt='' /> to select a message to send to the flow."
-                  },
-                  {
-                    "details":"Choose the ExampleInputMessage1, edit the message data if you like, and click Send. Your request message is sent to the HTTP input node.",
-                    "substeps":{
-                      "type":"unordered",
-                      "details":[
+        "pageDetails": 
+		{
+            "topicsName": "Tutorial Topics",
+            "_topicListComment": "A short list of product concepts or tasks demonstrated by this tutorial",
+            "topicList": 
+			[
+                {
+                    "title": "HTTP Input node"
+                },
+                {
+                    "title": "JSON parsing and writing"
+                },
+                {
+                    "title": "Transformation using graphical data mapping"
+                }
+            ],
+            "outcomesName": "Learning outcomes",
+            "_outcomesComment": "A description of what the user will have learned or accomplished by running this tutorial.",
+            "outcomeList": 
+			[
+                {
+                    "title": "Use IBM Integration Bus to create and invoke a JSON/HTTP request-response message flow."
+                }
+            ],
+            "summary": 
+			{
+                "overviewName": "OVERVIEW",
+                "_overviewComment": "A short description of what happens in this tutorial, and an optional short explanation of the IIB concepts used in this tutorial if necessary for context. What background knowledge must the user have for this to make sense?",
+                "sections": 
+				[
+                    {
+                        "section": "This tutorial demonstrates a simple message flow that receives JSON data over HTTP. The flow transforms the input JSON structure into a different output JSON structure using a graphical data mapping node, and sends this back to the HTTP request."
+                    },
+                    {
+                        "section": "In IBM Integration Bus, an application is a container for all the resources that are required to create a solution. An application can contain IBM Integration Bus resources, such as flows, message definitions, libraries, and JAR files. An application is used to hold the message flow in this tutorial.  If you have a WSDL document that describes a SOAP/HTTP interface you might consider using an integration service instead. See the Integration services (SOAP/HTTP inputs) tutorial for more details."
+                    }
+                ]
+            }
+        },
+        "pageSteps": 
+		{
+            "concept": 
+			{
+                "overview": 
+				{
+                    "name": "Overview",
+                    "heading": "Overview",
+                    "_overviewComment": "A short description of what this tutorial does, and what the user will do to run the tutorial.",
+                    "sections": 
+					[
                         {
-                          "details":"Substep one"
+                            "section": "This tutorial demonstrates a simple message flow that receives JSON data over HTTP. The flow transforms the input JSON structure into a different output JSON structure using a graphical data mapping node and sends this back to the HTTP request."
                         },
                         {
-                          "details":"Substep two"
+                            "section": "You will import the message flow to your Integration Toolkit workspace, deploy it to your default integration server, and invoke the message flow by using the Flow exerciser."
                         }
-                      ]
-                    }
-                  }
-                ]
-              }
+                    ]
+                },
+                "helpLinks": 
+				{
+                    "_helpLinksComment": "Helplinks that have a type:web attribute are rendered as web links. Otherwise, links are assumed to be to embedded Help topics in the Knowledge Center.",
+                    "title": "Find out more",
+                    "details": 
+					[
+                        {
+                            "title": "Knowledge Center link to ",
+                            "description": "Developing integration solutions by using applications",
+                            "link": "com.ibm.etools.mft.doc/bi12002_.htm",
+                            "type": "help"
+                        },
+                        {
+                            "title": "GitHub link to ",
+                            "description": "DFDL Schemas",
+                            "link": "http://github.com/DFDLSchemas",
+                            "type": "web"
+                        }
+                    ]
+                }
             },
-            {
-              "section":"After the request message is processed, the message path is automatically highlighted on the message flow."
+            "create": 
+			{
+                "overview": 
+				{
+                    "name": "Create",
+                    "heading": "Import projects",
+                    "_createComment": "A description of what will happen when the user clicks Import.",
+                    "sections": 
+					[
+                        {
+                            "section": "The HTTPInputApplication application includes one project that is imported into your workspace."
+                        }
+                    ]
+                },
+                "helpLinks": 
+				{
+                    "title": "Find out more",
+                    "details": 
+					[
+                        {
+                            "title": "Knowledge Center link to ",
+                            "description": "Developing integration solutions by using applications",
+                            "link": "com.ibm.etools.mft.doc/bi12002_.htm"
+                        }
+                    ]
+                },
+                "actions": 
+				{
+                    "title": "Create Actions",
+                    "details": 
+					[
+                        {
+                            "name": "Import",
+                            "method": "importArtifacts()"
+                        }
+                    ]
+                }
             },
-            {
-              "section":"Click on any connection to see the data that passed through that connection. You can see that the request (input) message data has two fields named InputField1 and InputField2. The response (output) message has converted this to fields named OutputField1 and OutputField2."
+            "prepare": 
+			{
+                "overview": 
+				{
+                    "name": "Prepare",
+                    "heading": "Imported projects",
+                    "_prepareComment": "A description of what just happened when the user clicked Import, and what will happen when the user clicks Deploy.",
+                    "sections": 
+					[
+                        {
+                            "section": "The HTTPInputApplication application is shown in the Application Development view of your workspace."
+                        },
+                        {
+                            "section": ""
+                        },
+                        {
+                            "section": "The application will be deployed to your default integration server. The message flow is then running on your integration server and ready to process messages."
+                        }
+                    ]
+                },
+                "helpLinks": 
+				{
+                    "title": "Find out more",
+                    "details": 
+					[
+                        {
+                            "title": "Knowledge Center link to ",
+                            "description": "Developing integration solutions by using integration services",
+                            "link": "com.ibm.etools.mft.doc/bi12002_.htm"
+                        }
+                    ]
+                },
+                "actions-removed": 
+				{
+                    "title": "Prepare Actions",
+                    "details": 
+					[
+                        {
+                            "name": "Deploy",
+                            "method": "deployArtifacts()"
+                        }
+                    ]
+                }
+            },
+            "run": 
+			{
+                "overview": 
+				{
+                    "name": "Run",
+                    "heading": "Follow these steps to complete the tutorial",
+                    "_runComment": "The full steps for the user to run through the tutorial. Use 'sections' to render paragraphs, 'steps' with a type of 'ordered' or 'unordered' to render HTML lists, and 'substeps' to render nested lists.",
+                    "sections": 
+					[
+                        {
+                            "section": "The HTTPInputApplication application is shown in the Application Development view of your workspace.",
+                            "steps": 
+							{
+                                "type": "ordered",
+                                "details": 
+								[
+                                    {
+                                        "details": "Open the HTTPInputMessageFlow, and click the Flow Exerciser icon <img src='http://ot4i.github.io/ot4i.tutorials/dist/images/icons/iib/startFlowExerciser.png' alt='' /> to start recording the message path through the flow."
+                                    },
+                                    {
+                                        "details": "Click the Send Message icon <img src='http://ot4i.github.io/ot4i.tutorials/dist/images/icons/iib/sendMessage.png' alt='' /> to select a message to send to the flow."
+                                    },
+                                    {
+                                        "details": "Choose the ExampleInputMessage1, edit the message data if you like, and click Send. Your request message is sent to the HTTP input node.",
+                                        "substeps": 
+										{
+                                            "type": "unordered",
+                                            "details": 
+											[
+                                                {
+                                                    "details": "Substep one"
+                                                },
+                                                {
+                                                    "details": "Substep two"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "section": "After the request message is processed, the message path is automatically highlighted on the message flow."
+                        },
+                        {
+                            "section": "Click on any connection to see the data that passed through that connection. You can see that the request (input) message data has two fields named InputField1 and InputField2. The response (output) message has converted this to fields named OutputField1 and OutputField2."
+                        }
+                    ]
+                },
+                "helpLinks": 
+				{
+                    "title": "Find out more",
+                    "details": 
+					[
+                        {
+                            "title": "Knowledge Center link to ",
+                            "description": "Developing integration solutions by using applications",
+                            "link": "com.ibm.etools.mft.doc/bi12002_.htm"
+                        },
+                        {
+                            "title": "Knowledge Center link to ",
+                            "description": "Testing your message flow by using the Flow exerciser",
+                            "link": "com.ibm.etools.mft.doc/rt26110_.htm"
+                        }
+                    ]
+                },
+                "actions": 
+				{
+                    "title": "Run Actions",
+                    "details": 
+					[
+                        {
+                            "name": "Deploy",
+                            "method": "deployArtifacts()"
+                        }
+                    ]
+                },
+				"exits": 
+				{
+					"title": "Run Exits",
+					"details": 
+					[
+						{
+							"name": "Clean Up",
+							"description": "Clean up and remove any changes in your workspace made by the tutorial.",
+							"method": "cleanUp()"
+						}
+					]
+				}
             }
-          ]
-        },
-        "helpLinks":{
-          "title":"Find out more",
-          "details":[
-            {
-              "title":"Knowledge Center link to ",
-              "description":"Developing integration solutions by using applications",
-              "link":"com.ibm.etools.mft.doc/bi12002_.htm"
-            },
-            {
-              "title":"Knowledge Center link to ",
-              "description":"Testing your message flow by using the Flow exerciser",
-              "link":"com.ibm.etools.mft.doc/rt26110_.htm"
-            }
-          ]
         }
-      }
     }
-  }
 }


### PR DESCRIPTION
1.1 Steps template: Make actions on Create and Run Tabs non-hardcoded and multiple.
1.2  Steps template: Remove actions from Prepare as this step should be user focused, not system focused.
Reaffirm "contract" and user's expectation as to what has happened on Create step and what is going to happen.
1.4  Steps template: On Run tab, move deploy action here and demarcate clean up as an exit step, not another action.

This means:
a. Modifying the HarpJs template code in the Steps.ejs template
b. Adding further fields to the _data.json file.

Based on User Feedback - Did not do the secondary navigation as it was confusing for user and inconsistent navigation/interaction behaviour.
