### PR TITLE
Bug-fix for path literal string in the iib icon URL for tutorial JSON de...

### DIFF
--- a/src/tutorialExample/en/_data.json
+++ b/src/tutorialExample/en/_data.json
@@ -216,10 +216,10 @@
                                 "details": 
 								[
                                     {
-                                        "details": "Open the HTTPInputMessageFlow, and click the Flow Exerciser icon <img src='<%= header.repoUrlProtocol %><%= header.repoUrlSite %>/dist/images/icons/iib/startFlowExerciser.png' alt='' /> to start recording the message path through the flow."
+                                        "details": "Open the HTTPInputMessageFlow, and click the Flow Exerciser icon <img src='<%= header.repoUrlProtocol %><%= header.repoUrlSite %>/ot4i.tutorials//dist/images/icons/iib/startFlowExerciser.png' alt='' /> to start recording the message path through the flow."
                                     },
                                     {
-                                        "details": "Click the Send Message icon <img src='<%= header.repoUrlProtocol %><%= header.repoUrlSite %>/dist/images/icons/iib/sendMessage.png' alt='' /> to select a message to send to the flow."
+                                        "details": "Click the Send Message icon <img src='<%= header.repoUrlProtocol %><%= header.repoUrlSite %>/ot4i.tutorials/dist/images/icons/iib/sendMessage.png' alt='' /> to select a message to send to the flow."
                                     },
                                     {
                                         "details": "Choose the ExampleInputMessage1, edit the message data if you like, and click Send. Your request message is sent to the HTTP input node.",


### PR DESCRIPTION
Fix for iib icon URL path string.

Was:
<img src='<%= header.repoUrlProtocol %><%= header.repoUrlSite %>/dist/images/icons/iib/startFlowExerciser.png' alt='' />

Changed to:
<img src='<%= header.repoUrlProtocol %><%= header.repoUrlSite %>/ot4i.tutorials/dist/images/icons/iib/startFlowExerciser.png' alt='' />
